### PR TITLE
Fix unsoundness and simplify Value/Object APIs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["portable"]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mu_derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mu_diag"
 version = "0.0.1"
 dependencies = [
@@ -382,6 +391,7 @@ dependencies = [
  "indexmap",
  "indoc",
  "insta",
+ "mu_derive",
  "mu_diag",
  "mu_emit",
  "mu_op",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,5 @@
 [workspace]
-members = [
-  "crates/diag",
-  "crates/emit",
-  "crates/op",
-  "crates/runtime",
-  "crates/span",
-  "crates/syntax",
-  "crates/cli",
-]
+members = ["crates/*"]
 resolver = "2"
 
 # TODO: list shared dependencies here https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mu_derive"
+version = "0.0.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
+quote = "1.0"
+syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/crates/derive/src/delegate.rs
+++ b/crates/derive/src/delegate.rs
@@ -1,0 +1,68 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{FnArg, ImplItemMethod, ItemImpl, Visibility};
+
+pub fn macro_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+  if !args.is_empty() {
+    return syn::Error::new(Span::call_site(), "attribute does not accept any arguments")
+      .into_compile_error()
+      .into();
+  }
+
+  let input = syn::parse_macro_input!(input as ItemImpl);
+
+  let generics = input.generics.clone();
+  let self_ty = input.self_ty.clone();
+  let mut methods = vec![];
+  for item in input.items.iter() {
+    match item {
+      syn::ImplItem::Method(method) => {
+        if matches!(
+          method.vis,
+          Visibility::Public(_) | Visibility::Crate(_) | Visibility::Restricted(_)
+        ) && matches!(method.sig.inputs.first(), Some(FnArg::Receiver(..)))
+        {
+          let ImplItemMethod {
+            attrs,
+            vis,
+            defaultness,
+            sig,
+            ..
+          } = method;
+          let FnArg::Receiver(receiver) = sig.inputs.first().unwrap() else { unreachable!() };
+          let getter = if receiver.mutability.is_some() {
+            Ident::new("_get_mut", Span::call_site())
+          } else {
+            Ident::new("_get", Span::call_site())
+          };
+
+          let name = sig.ident.clone();
+          let args = sig.inputs.iter().filter_map(|input| match input {
+            FnArg::Receiver(_) => None,
+            FnArg::Typed(v) => match &*v.pat {
+              syn::Pat::Ident(v) => Some(v.ident.clone()),
+              _ => None,
+            },
+          });
+          methods.push(quote! {
+            #(#attrs)*
+            #vis #defaultness #sig {
+              unsafe { self.#getter() }.#name(#(#args),*)
+            }
+          });
+        }
+      }
+      _ => todo!(),
+    }
+  }
+
+  quote! {
+    #input
+
+    impl #generics crate::value::object::Handle<#self_ty> {
+      #(#methods)*
+    }
+  }
+  .into()
+}

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -1,0 +1,9 @@
+use proc_macro::TokenStream;
+
+mod delegate;
+
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn delegate_to_handle(args: TokenStream, input: TokenStream) -> TokenStream {
+  delegate::macro_impl(args, input)
+}

--- a/crates/emit/src/ctx.rs
+++ b/crates/emit/src/ctx.rs
@@ -24,7 +24,7 @@ impl Context {
     if let Some(str) = inner.intern_table.get(str) {
       str.clone()
     } else {
-      let value = Handle::new(str);
+      let value = Handle::alloc(Str::from(str));
       inner.intern_table.insert(str.into(), Handle::clone(&value));
       value
     }

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-2.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(0)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 14
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-3.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(0, 1, 2)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 28
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-4.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(a=0)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 18
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-5.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-5.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(a=0, b=1, c=2)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 34
   const (length=4):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-6.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-6.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(a, b, c=2)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 26
   const (length=4):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-7.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-7.snap
@@ -6,7 +6,7 @@ expression: snapshot
 a(b(c()))
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 19
   const (length=3):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-8.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call-8.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f(a+b, c=a+b)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 31
   const (length=4):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__call.snap
@@ -6,7 +6,7 @@ expression: snapshot
 f()
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 5
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-10.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-10.snap
@@ -8,11 +8,11 @@ class T(U):
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 18
   const (length=3):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
     2: "T"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-11.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-11.snap
@@ -9,11 +9,11 @@ class T(U):
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 25
   const (length=3):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
     2: "T"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-12.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-12.snap
@@ -10,7 +10,7 @@ class T(U):
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 4
   length: 7
   const (length=1):
@@ -23,13 +23,13 @@ function <test>:
     5 | ret 
     6 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 22
   const (length=4):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
-    2: <func test>
+    2: <func "test">
     3: "T"
   code:
      0 | load_global [1]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-13.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-13.snap
@@ -11,7 +11,7 @@ class T(U):
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 5
   length: 17
   const (length=2):
@@ -30,14 +30,14 @@ function <test>:
     15 | ret 
     16 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 29
   const (length=5):
     0: "u"
-    1: <class desc T>
+    1: <class desc "T">
     2: "U"
-    3: <func test>
+    3: <func "test">
     4: "T"
   code:
      0 | push_small_int value=0

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-14.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-14.snap
@@ -12,7 +12,7 @@ fn test():
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 5
   length: 17
   const (length=1):
@@ -30,13 +30,13 @@ function <test>:
     15 | ret 
     16 | suspend 
 
-function <test>:
+function "test":
   frame_size: 8
   length: 33
   const (length=3):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
-    2: <closure desc test n=1>
+    2: <closure desc "test">
   code:
      0 | push_small_int value=0
      5 | store_reg r4
@@ -53,11 +53,11 @@ function <test>:
     31 | ret 
     32 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func test>
+    0: <func "test">
     1: "test"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-2.snap
@@ -8,11 +8,11 @@ class T:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 10
   const (length=2):
-    0: <class desc T>
+    0: <class desc "T">
     1: "T"
   code:
      0 | push_none 

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-3.snap
@@ -8,11 +8,11 @@ class T:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 14
   const (length=2):
-    0: <class desc T>
+    0: <class desc "T">
     1: "T"
   code:
      0 | push_small_int value=0

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-4.snap
@@ -9,11 +9,11 @@ class T:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 21
   const (length=2):
-    0: <class desc T>
+    0: <class desc "T">
     1: "T"
   code:
      0 | push_small_int value=0

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-5.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-5.snap
@@ -10,7 +10,7 @@ class T:
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 4
   length: 7
   const (length=1):
@@ -23,12 +23,12 @@ function <test>:
     5 | ret 
     6 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 18
   const (length=3):
-    0: <class desc T>
-    1: <func test>
+    0: <class desc "T">
+    1: <func "test">
     2: "T"
   code:
      0 | load_const [1]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-6.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-6.snap
@@ -11,7 +11,7 @@ class T:
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 5
   length: 17
   const (length=2):
@@ -30,13 +30,13 @@ function <test>:
     15 | ret 
     16 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 25
   const (length=4):
     0: "u"
-    1: <class desc T>
-    2: <func test>
+    1: <class desc "T">
+    2: <func "test">
     3: "T"
   code:
      0 | push_small_int value=0

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-7.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-7.snap
@@ -12,7 +12,7 @@ fn test():
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 5
   length: 17
   const (length=1):
@@ -30,12 +30,12 @@ function <test>:
     15 | ret 
     16 | suspend 
 
-function <test>:
+function "test":
   frame_size: 7
   length: 29
   const (length=2):
-    0: <class desc T>
-    1: <closure desc test n=1>
+    0: <class desc "T">
+    1: <closure desc "test">
   code:
      0 | push_small_int value=0
      5 | store_reg r4
@@ -50,11 +50,11 @@ function <test>:
     27 | ret 
     28 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func test>
+    0: <func "test">
     1: "test"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-8.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-8.snap
@@ -7,11 +7,11 @@ class T(U): pass
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 11
   const (length=3):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
     2: "T"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-9.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def-9.snap
@@ -8,11 +8,11 @@ class T(U):
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 14
   const (length=3):
-    0: <class desc T>
+    0: <class desc "T">
     1: "U"
     2: "T"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_def.snap
@@ -7,11 +7,11 @@ class T: pass
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <class desc T>
+    0: <class desc "T">
     1: "T"
   code:
     0 | create_class_empty [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_instance.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__class_instance.snap
@@ -9,11 +9,11 @@ T()
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 9
   const (length=2):
-    0: <class desc T>
+    0: <class desc "T">
     1: "T"
   code:
     0 | create_class_empty [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__closure-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__closure-2.snap
@@ -12,7 +12,7 @@ fn a():
 
 
 # Func:
-function <d>:
+function "d":
   frame_size: 4
   length: 6
   const: <empty>
@@ -23,11 +23,11 @@ function <d>:
     4 | ret 
     5 | suspend 
 
-function <c>:
+function "c":
   frame_size: 5
   length: 10
   const (length=1):
-    0: <closure desc d n=1>
+    0: <closure desc "d">
   code:
      0 | create_closure [0]
      2 | capture_slot parent_slot=0, self_slot=0
@@ -36,11 +36,11 @@ function <c>:
      8 | ret 
      9 | suspend 
 
-function <b>:
+function "b":
   frame_size: 5
   length: 10
   const (length=1):
-    0: <closure desc c n=1>
+    0: <closure desc "c">
   code:
      0 | create_closure [0]
      2 | capture_slot parent_slot=0, self_slot=0
@@ -49,11 +49,11 @@ function <b>:
      8 | ret 
      9 | suspend 
 
-function <a>:
+function "a":
   frame_size: 5
   length: 17
   const (length=1):
-    0: <closure desc b n=1>
+    0: <closure desc "b">
   code:
      0 | push_small_int value=0
      5 | store_reg r4
@@ -64,11 +64,11 @@ function <a>:
     15 | ret 
     16 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func a>
+    0: <func "a">
     1: "a"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__closure.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__closure.snap
@@ -13,7 +13,7 @@ a()()
 
 
 # Func:
-function <b>:
+function "b":
   frame_size: 4
   length: 6
   const: <empty>
@@ -24,11 +24,11 @@ function <b>:
     4 | ret 
     5 | suspend 
 
-function <a>:
+function "a":
   frame_size: 5
   length: 18
   const (length=1):
-    0: <closure desc b n=1>
+    0: <closure desc "b">
   code:
      0 | push_small_int value=0
      5 | store_reg r4
@@ -39,11 +39,11 @@ function <a>:
     16 | ret 
     17 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 10
   const (length=2):
-    0: <func a>
+    0: <func "a">
     1: "a"
   code:
      0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-2.snap
@@ -8,7 +8,7 @@ for i in 0..=10:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 56
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-3.snap
@@ -8,7 +8,7 @@ for i in 0..=10:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 59
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt-4.snap
@@ -8,7 +8,7 @@ for i in 0..=10:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 59
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__for_loop_stmt.snap
@@ -8,7 +8,7 @@ for i in 0..10:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 56
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-2.snap
@@ -10,7 +10,7 @@ test(0)
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 5
   length: 6
   const: <empty>
@@ -21,11 +21,11 @@ function <test>:
     4 | ret 
     5 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 18
   const (length=2):
-    0: <func test>
+    0: <func "test">
     1: "test"
   code:
      0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-3.snap
@@ -11,7 +11,7 @@ test(1, 2)
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 7
   length: 31
   const: <empty>
@@ -35,11 +35,11 @@ function <test>:
     29 | ret 
     30 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 37
   const (length=2):
-    0: <func test>
+    0: <func "test">
     1: "test"
   code:
      0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-4.snap
@@ -10,7 +10,7 @@ test(1, b=2)
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 7
   length: 19
   const (length=1):
@@ -28,11 +28,11 @@ function <test>:
     17 | ret 
     18 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 29
   const (length=3):
-    0: <func test>
+    0: <func "test">
     1: "test"
     2: "b"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-5.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-5.snap
@@ -11,7 +11,7 @@ test(1, b=2)
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 7
   length: 40
   const (length=1):
@@ -42,11 +42,11 @@ function <test>:
     38 | ret 
     39 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 41
   const (length=3):
-    0: <func test>
+    0: <func "test">
     1: "test"
     2: "b"
   code:

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-6.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func-6.snap
@@ -11,7 +11,7 @@ test(1, 2, b=3, c=4)
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 7
   length: 48
   const (length=1):
@@ -46,11 +46,11 @@ function <test>:
     46 | ret 
     47 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 63
   const (length=4):
-    0: <func test>
+    0: <func "test">
     1: "test"
     2: "b"
     3: "c"

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__func.snap
@@ -10,7 +10,7 @@ test()
 
 
 # Func:
-function <test>:
+function "test":
   frame_size: 4
   length: 3
   const: <empty>
@@ -19,11 +19,11 @@ function <test>:
     1 | ret 
     2 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 9
   const (length=2):
-    0: <func test>
+    0: <func "test">
     1: "test"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__if_stmt-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__if_stmt-2.snap
@@ -11,7 +11,7 @@ else:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 26
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__if_stmt.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__if_stmt.snap
@@ -12,7 +12,7 @@ else:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 37
   const (length=3):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-2.snap
@@ -10,7 +10,7 @@ fn main():
 
 
 # Func:
-function <main>:
+function "main":
   frame_size: 5
   length: 9
   const (length=1):
@@ -23,11 +23,11 @@ function <main>:
     7 | ret 
     8 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func main>
+    0: <func "main">
     1: "main"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-3.snap
@@ -10,7 +10,7 @@ fn main():
 
 
 # Func:
-function <main>:
+function "main":
   frame_size: 7
   length: 22
   const (length=2):
@@ -30,11 +30,11 @@ function <main>:
     20 | ret 
     21 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func main>
+    0: <func "main">
     1: "main"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports-4.snap
@@ -14,7 +14,7 @@ fn main():
 
 
 # Func:
-function <main>:
+function "main":
   frame_size: 9
   length: 41
   const (length=4):
@@ -45,11 +45,11 @@ function <main>:
     39 | ret 
     40 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func main>
+    0: <func "main">
     1: "main"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__imports.snap
@@ -10,7 +10,7 @@ fn main():
 
 
 # Func:
-function <main>:
+function "main":
   frame_size: 5
   length: 11
   const (length=2):
@@ -25,11 +25,11 @@ function <main>:
      9 | ret 
     10 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 6
   const (length=2):
-    0: <func main>
+    0: <func "main">
     1: "main"
   code:
     0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__logical_expr.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__logical_expr.snap
@@ -24,7 +24,7 @@ fn f3(a, b, c, d):
 
 
 # Func:
-function <f0>:
+function "f0":
   frame_size: 7
   length: 50
   const: <empty>
@@ -67,7 +67,7 @@ function <f0>:
     48 | ret 
     49 | suspend 
 
-function <f1_a>:
+function "f1_a":
   frame_size: 8
   length: 35
   const: <empty>
@@ -100,7 +100,7 @@ function <f1_a>:
     33 | ret 
     34 | suspend 
 
-function <f1_b>:
+function "f1_b":
   frame_size: 8
   length: 35
   const: <empty>
@@ -133,7 +133,7 @@ function <f1_b>:
     33 | ret 
     34 | suspend 
 
-function <f2_a>:
+function "f2_a":
   frame_size: 8
   length: 41
   const: <empty>
@@ -171,7 +171,7 @@ function <f2_a>:
     39 | ret 
     40 | suspend 
 
-function <f2_b>:
+function "f2_b":
   frame_size: 8
   length: 41
   const: <empty>
@@ -209,7 +209,7 @@ function <f2_b>:
     39 | ret 
     40 | suspend 
 
-function <f3>:
+function "f3":
   frame_size: 9
   length: 43
   const: <empty>
@@ -247,21 +247,21 @@ function <f3>:
     41 | ret 
     42 | suspend 
 
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 26
   const (length=12):
-    0: <func f0>
+    0: <func "f0">
     1: "f0"
-    2: <func f1_a>
+    2: <func "f1_a">
     3: "f1_a"
-    4: <func f1_b>
+    4: <func "f1_b">
     5: "f1_b"
-    6: <func f2_a>
+    6: <func "f2_a">
     7: "f2_a"
-    8: <func f2_b>
+    8: <func "f2_b">
     9: "f2_b"
-    10: <func f3>
+    10: <func "f3">
     11: "f3"
   code:
      0 | load_const [0]

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-10.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-10.snap
@@ -10,7 +10,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 33
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-11.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-11.snap
@@ -10,7 +10,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 33
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-12.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-12.snap
@@ -10,7 +10,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 40
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-13.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-13.snap
@@ -10,7 +10,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 26
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-14.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-14.snap
@@ -10,7 +10,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 33
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-15.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-15.snap
@@ -10,7 +10,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 33
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-2.snap
@@ -8,7 +8,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 14
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-3.snap
@@ -8,7 +8,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 14
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-4.snap
@@ -8,7 +8,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 18
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-5.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-5.snap
@@ -8,7 +8,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 21
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-6.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-6.snap
@@ -8,7 +8,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 21
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-7.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-7.snap
@@ -11,7 +11,7 @@ print "now it's 10"
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 61
   const (length=3):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-8.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-8.snap
@@ -10,7 +10,7 @@ while true:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 40
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-9.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt-9.snap
@@ -10,7 +10,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 26
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__loop_stmt.snap
@@ -8,7 +8,7 @@ loop:
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 11
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-2.snap
@@ -6,7 +6,7 @@ expression: snapshot
 o.f(0)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 16
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-3.snap
@@ -6,7 +6,7 @@ expression: snapshot
 o.f(1,2,3)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 30
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call-4.snap
@@ -6,7 +6,7 @@ expression: snapshot
 o.f(1,2,c=3)
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 34
   const (length=3):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__method_call.snap
@@ -6,7 +6,7 @@ expression: snapshot
 o.f()
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 7
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-2.snap
@@ -9,7 +9,7 @@ v["a"] = 1
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 46
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-3.snap
@@ -9,7 +9,7 @@ print ?v.a.b.c
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 23
   const (length=4):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field-4.snap
@@ -9,7 +9,7 @@ print ?v["a"]["b"]["c"]
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 7
   length: 39
   const (length=4):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_field.snap
@@ -9,7 +9,7 @@ v.a = 1
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 38
   const (length=2):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-2.snap
@@ -6,7 +6,7 @@ expression: snapshot
 print 2.5
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 5
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-3.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-3.snap
@@ -6,7 +6,7 @@ expression: snapshot
 print "test"
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 5
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-4.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-4.snap
@@ -6,7 +6,7 @@ expression: snapshot
 print [0, 1, 2]
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 5
   length: 29
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-5.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals-5.snap
@@ -6,7 +6,7 @@ expression: snapshot
 print { a: 0, b: 1, c: 2 }
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 6
   length: 44
   const (length=3):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_literals.snap
@@ -6,7 +6,7 @@ expression: snapshot
 print 0
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 8
   const: <empty>

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_variable-2.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_variable-2.snap
@@ -7,7 +7,7 @@ print v # load_global
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 5
   const (length=1):

--- a/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_variable.snap
+++ b/crates/emit/src/emitter/snapshots/mu_emit__emitter__tests__print_variable.snap
@@ -8,7 +8,7 @@ print v # load_reg
 
 
 # Func:
-function <[[main]]>:
+function "code":
   frame_size: 4
   length: 12
   const (length=1):

--- a/crates/emit/src/emitter/tests.rs
+++ b/crates/emit/src/emitter/tests.rs
@@ -1,3 +1,5 @@
+use runtime::value::object::Handle;
+
 use super::*;
 
 macro_rules! check {
@@ -12,7 +14,7 @@ macro_rules! check {
         panic!("Failed to parse source, see errors above.")
       }
     };
-    let result = match Emitter::new(&Context::new(), "[[main]]", &module).emit_main() {
+    let result = match Emitter::new(&Context::new(), "code", &module).emit_main() {
       Ok(result) => result,
       Err(e) => {
         panic!("failed to emit func:\n{}", e.report(input));
@@ -20,11 +22,10 @@ macro_rules! check {
     };
     let tracking = result.regalloc.get_tracking();
     let tracking = tracking.borrow();
-    let func = Value::from(result.func);
-    let func = func.as_func().unwrap();
+    let func = Handle::alloc(result.func);
     let snapshot = format!(
       "# Input:\n{input}\n\n# Func:\n{}\n\n# Regalloc:\n{}",
-      func.disassemble(op::disassemble, false),
+      func.disassemble(false),
       crate::regalloc::DisplayTracking(&tracking),
     );
     insta::assert_snapshot!(snapshot);

--- a/crates/op/src/instruction.rs
+++ b/crates/op/src/instruction.rs
@@ -770,7 +770,7 @@ impl<Value: std::fmt::Display + Hash + Eq + Clone> Chunk<Value> {
       let f = &mut f;
 
       // name
-      writeln!(f, "function <{}>:", self.name).unwrap();
+      writeln!(f, "function \"{}\":", self.name).unwrap();
       writeln!(f, "  length: {}", self.bytecode.len()).unwrap();
 
       // constants

--- a/crates/op/src/snapshots/mu_op__tests__builder.snap
+++ b/crates/op/src/snapshots/mu_op__tests__builder.snap
@@ -2,7 +2,7 @@
 source: crates/op/src/tests.rs
 expression: chunk.disassemble(false)
 ---
-function <test>:
+function "test":
   length: 72
   const_pool (length=3):
     0 = "test"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -16,6 +16,8 @@ span = { path = "../span", package = "mu_span" }
 indexmap = "1.9.2"
 paste = "1.0.11"
 
+derive = { path = "../derive", package = "mu_derive" }
+
 [dev-dependencies]
 indoc = "1.0.8"
 insta = "1.23.0"

--- a/crates/runtime/src/isolate/binop.rs
+++ b/crates/runtime/src/isolate/binop.rs
@@ -3,16 +3,16 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 use crate::{Error, Result, Value};
 
 pub fn add(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::int(lhs.add(rhs)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).add(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::float(lhs.add(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.add(rhs)));
     }
   }
@@ -22,16 +22,16 @@ pub fn add(lhs: Value, rhs: Value) -> Result<Value> {
 }
 
 pub fn sub(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::int(lhs.sub(rhs)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).sub(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::float(lhs.sub(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.sub(rhs)));
     }
   }
@@ -41,16 +41,16 @@ pub fn sub(lhs: Value, rhs: Value) -> Result<Value> {
 }
 
 pub fn mul(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::int(lhs.mul(rhs)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).mul(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::float(lhs.mul(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.mul(rhs)));
     }
   }
@@ -60,22 +60,22 @@ pub fn mul(lhs: Value, rhs: Value) -> Result<Value> {
 }
 
 pub fn div(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       if rhs == 0 {
         return Ok(Value::float((lhs as f64).div(rhs as f64)));
       }
       return Ok(Value::int(lhs.div(rhs)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).div(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       if rhs == 0 {
         return Ok(Value::float(lhs.div(rhs as f64)));
       }
       return Ok(Value::float(lhs.div(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.div(rhs)));
     }
   }
@@ -85,22 +85,22 @@ pub fn div(lhs: Value, rhs: Value) -> Result<Value> {
 }
 
 pub fn rem(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       if rhs == 0 {
         return Ok(Value::float((lhs as f64).rem(rhs as f64)));
       }
       return Ok(Value::int(lhs.rem(rhs)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).rem(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       if rhs == 0 {
         return Ok(Value::float(lhs.rem(rhs as f64)));
       }
       return Ok(Value::float(lhs.rem(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.rem(rhs)));
     }
   }
@@ -110,8 +110,8 @@ pub fn rem(lhs: Value, rhs: Value) -> Result<Value> {
 }
 
 pub fn pow(lhs: Value, rhs: Value) -> Result<Value> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return if rhs < 0 {
         let rhs = (-rhs) as u32;
         let denom = lhs.pow(rhs) as f64;
@@ -120,13 +120,13 @@ pub fn pow(lhs: Value, rhs: Value) -> Result<Value> {
         let rhs = rhs as u32;
         Ok(Value::int(lhs.pow(rhs)))
       };
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float((lhs as f64).powf(rhs)));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(Value::float(lhs.powf(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(Value::float(lhs.powf(rhs)));
     }
   }

--- a/crates/runtime/src/isolate/class.rs
+++ b/crates/runtime/src/isolate/class.rs
@@ -1,6 +1,6 @@
 use super::{call, Isolate};
 use crate::value::object::handle::Handle;
-use crate::value::object::{ClassDef, Dict, Method};
+use crate::value::object::{ClassDef, Method};
 use crate::value::Value;
 use crate::Result;
 
@@ -11,33 +11,32 @@ pub fn create_instance<Io: std::io::Write>(
   kwargs: Value,
 ) -> Result<Value> {
   // create instance
-  let mut class = def.instance();
+  let mut class = Handle::alloc(def.instance());
 
-  if class.get("init").is_some() {
+  if class.has("init") {
     let init = class.get("init").unwrap().clone();
     // call initializer
     // TODO: don't allocate temp object here
     vm.call(
-      Method {
-        this: class.clone().into(),
-        func: init,
-      }
-      .into(),
+      Value::object(Handle::alloc(Method::new(
+        Value::object(class.clone()),
+        init,
+      ))),
       args,
       kwargs,
     )?;
   } else {
     // assign kwargs to fields
-    if let Some(kwargs) = kwargs.as_dict() {
-      call::check_args(true, def.params(), args, kwargs)?;
+    if let Some(kwargs) = kwargs.to_dict() {
+      call::check_args(true, def.params(), args, Some(kwargs.clone()))?;
       for (k, v) in kwargs.iter() {
         class.insert(k.clone(), v.clone());
       }
     } else {
-      call::check_args(true, def.params(), args, &Dict::new())?;
+      call::check_args(true, def.params(), args, None)?;
     }
   }
-
   class.freeze();
-  Ok(class.widen().into())
+
+  Ok(Value::object(class))
 }

--- a/crates/runtime/src/isolate/cmp.rs
+++ b/crates/runtime/src/isolate/cmp.rs
@@ -4,16 +4,16 @@ use super::*;
 use crate::{Error, Result};
 
 pub fn partial_cmp(lhs: Value, rhs: Value) -> Result<Option<Ordering>> {
-  if let Some(lhs) = lhs.as_int() {
-    if let Some(rhs) = rhs.as_int() {
+  if let Some(lhs) = lhs.clone().to_int() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(lhs.partial_cmp(&rhs));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok((lhs as f64).partial_cmp(&rhs));
     }
-  } else if let Some(lhs) = lhs.as_float() {
-    if let Some(rhs) = rhs.as_int() {
+  } else if let Some(lhs) = lhs.to_float() {
+    if let Some(rhs) = rhs.clone().to_int() {
       return Ok(lhs.partial_cmp(&(rhs as f64)));
-    } else if let Some(rhs) = rhs.as_float() {
+    } else if let Some(rhs) = rhs.to_float() {
       return Ok(lhs.partial_cmp(&rhs));
     }
   }

--- a/crates/runtime/src/isolate/field.rs
+++ b/crates/runtime/src/isolate/field.rs
@@ -1,10 +1,9 @@
-use crate::value::object::dict::Key;
-use crate::value::object::{Access, Method};
+use crate::value::object::{Access, Handle, Key, Method};
 use crate::value::Value;
 use crate::{Error, Result};
 
-pub fn set(obj: &mut Value, key: &str, value: Value) -> Result<()> {
-  if let Some(obj) = obj.as_object_mut() {
+pub fn set(receiver: &mut Value, key: &str, value: Value) -> Result<()> {
+  if let Some(mut obj) = receiver.clone().to_object_raw() {
     let key = Key::from(key);
     if obj.field_get(&key)?.is_some() || !obj.is_frozen() {
       obj.field_set(key.to_static(), value)?;
@@ -13,51 +12,45 @@ pub fn set(obj: &mut Value, key: &str, value: Value) -> Result<()> {
   };
 
   Err(Error::new(
-    format!("cannot set field `{key}` on value `{obj}`"),
+    format!("cannot set field `{key}` on value `{receiver}`"),
     0..0,
   ))
 }
 
-pub fn get(obj: &Value, key: &str) -> Result<Value> {
-  if let Some(o) = obj.as_object() {
+pub fn get(receiver: &Value, key: &str) -> Result<Value> {
+  if let Some(o) = receiver.clone().to_object_raw() {
     let key = Key::from(key);
     if let Some(value) = o.field_get(&key)? {
       if o.should_bind_methods() && is_fn_like(&value) {
-        return Ok(
-          Method {
-            this: obj.clone(),
-            func: value,
-          }
-          .into(),
-        );
+        return Ok(Value::object(Handle::alloc(Method::new(
+          receiver.clone(),
+          value,
+        ))));
       }
       return Ok(value);
     }
   }
 
   Err(Error::new(
-    format!("cannot get field `{key}` on value `{obj}`"),
+    format!("cannot get field `{key}` on value `{receiver}`"),
     0..0,
   ))
 }
 
-pub fn get_opt(obj: &Value, key: &str) -> Result<Value> {
+pub fn get_opt(receiver: &Value, key: &str) -> Result<Value> {
   // early exit if on `none`
-  if obj.is_none() {
+  if receiver.is_none() {
     return Ok(Value::none());
   }
 
-  if let Some(o) = obj.as_object() {
+  if let Some(o) = receiver.clone().to_object_raw() {
     let key = Key::from(key);
     if let Some(value) = o.field_get(&key)? {
       if o.should_bind_methods() && is_fn_like(&value) {
-        return Ok(
-          Method {
-            this: obj.clone(),
-            func: value,
-          }
-          .into(),
-        );
+        return Ok(Value::object(Handle::alloc(Method::new(
+          receiver.clone(),
+          value,
+        ))));
       }
       return Ok(value);
     }

--- a/crates/runtime/src/isolate/index.rs
+++ b/crates/runtime/src/isolate/index.rs
@@ -1,10 +1,9 @@
-use crate::value::object::dict::{Key, StaticKey};
-use crate::value::object::Access;
+use crate::value::object::{Access, Key, StaticKey};
 use crate::value::Value;
 use crate::{Error, Result};
 
 pub fn set(obj: &mut Value, key: StaticKey, value: Value) -> Result<()> {
-  if let Some(obj) = obj.as_object_mut() {
+  if let Some(mut obj) = obj.clone().to_object_raw() {
     if obj.index_get(&key)?.is_some() || !obj.is_frozen() {
       obj.index_set(key.to_static(), value)?;
       return Ok(());
@@ -18,7 +17,7 @@ pub fn set(obj: &mut Value, key: StaticKey, value: Value) -> Result<()> {
 }
 
 pub fn get(obj: &Value, key: &Key) -> Result<Value> {
-  if let Some(o) = obj.as_object() {
+  if let Some(o) = obj.clone().to_object_raw() {
     if let Some(value) = o.index_get(key)? {
       return Ok(value);
     }
@@ -36,7 +35,7 @@ pub fn get_opt(obj: &Value, key: &Key) -> Result<Value> {
     return Ok(Value::none());
   }
 
-  if let Some(o) = obj.as_object() {
+  if let Some(o) = obj.clone().to_object_raw() {
     if let Some(value) = o.index_get(key)? {
       return Ok(value);
     }

--- a/crates/runtime/src/isolate/string.rs
+++ b/crates/runtime/src/isolate/string.rs
@@ -1,0 +1,35 @@
+use std::fmt::Display;
+
+use crate::value::object::Str;
+use crate::{Handle, Value};
+
+pub fn stringify(value: Value) -> DeferString {
+  let inner = match value.is_str() {
+    true => DeferStringInner::String(value.to_str().unwrap()),
+    false => DeferStringInner::Other(value),
+  };
+
+  DeferString(inner)
+}
+
+pub struct DeferString(DeferStringInner);
+
+enum DeferStringInner {
+  String(Handle<Str>),
+  Other(Value),
+}
+
+impl Display for DeferStringInner {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      DeferStringInner::String(s) => write!(f, "{}", s.as_str()),
+      DeferStringInner::Other(v) => write!(f, "{v}"),
+    }
+  }
+}
+
+impl Display for DeferString {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}

--- a/crates/runtime/src/isolate/truth.rs
+++ b/crates/runtime/src/isolate/truth.rs
@@ -8,11 +8,11 @@ use crate::value::Value;
 ///
 /// Otherwise, it returns `true`.
 pub fn truthiness(v: Value) -> bool {
-  if let Some(v) = v.as_bool() {
+  if let Some(v) = v.clone().to_bool() {
     v
-  } else if let Some(v) = v.as_int() {
+  } else if let Some(v) = v.clone().to_int() {
     v != 0
-  } else if let Some(v) = v.as_float() {
+  } else if let Some(v) = v.to_float() {
     !v.is_nan() && v != 0.0
   } else {
     true

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,13 +1,10 @@
+#![allow(clippy::wrong_self_convention)]
+
 pub mod isolate;
 mod util;
 pub mod value;
 
 /*
-TODO: some cleanup after the vm+value merge
-
-- `util`
-- `error`
-
 
 TODO: carefully design the public API
 - Value
@@ -19,7 +16,7 @@ TODO: carefully design the public API
 */
 
 pub use isolate::Isolate;
-pub use value::object::Error;
+pub use value::object::{Error, Handle};
 pub use value::Value;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/value/mod.rs
+++ b/crates/runtime/src/value/mod.rs
@@ -5,11 +5,8 @@ pub mod object;
 pub mod ptr;
 
 use object::handle::Handle;
-use object::ObjectHandle;
+use object::ObjectType;
 use ptr::*;
-
-// TODO: remove Hash and Eq from `Value`, only `Key` needs to implement those
-// directly, rest can be implemented at the VM level
 
 #[cfg(not(feature = "portable"))]
 #[path = "impl/nanbox.rs"]
@@ -27,79 +24,19 @@ impl Default for Value {
   }
 }
 
-impl From<f64> for Value {
-  fn from(value: f64) -> Self {
-    Value::float(value)
-  }
-}
-
-impl From<i32> for Value {
-  fn from(value: i32) -> Self {
-    Value::int(value)
-  }
-}
-
-impl From<bool> for Value {
-  fn from(value: bool) -> Self {
-    Value::bool(value)
-  }
-}
-
-impl From<()> for Value {
-  fn from(_: ()) -> Self {
-    Value::none()
-  }
-}
-
-impl<T> From<T> for Value
-where
-  object::Object: From<T>,
-{
-  fn from(value: T) -> Self {
-    Value::object(Ptr::new(object::Object::from(value)))
-  }
-}
-
-impl<T> From<Option<T>> for Value
-where
-  Value: From<T>,
-{
-  fn from(value: Option<T>) -> Self {
-    match value {
-      Some(value) => Self::from(value),
-      None => Self::none(),
-    }
-  }
-}
-
-impl From<Ptr<object::Object>> for Value {
-  fn from(value: Ptr<object::Object>) -> Self {
-    Value::object(value)
-  }
-}
-
-impl<T> From<Handle<T>> for Value
-where
-  T: ObjectHandle,
-{
-  fn from(value: Handle<T>) -> Self {
-    Value::object(value.widen())
-  }
-}
-
 impl std::fmt::Display for Value {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     let v = self.clone();
-    if let Some(v) = v.as_float() {
+    if let Some(v) = v.clone().to_float() {
       write!(f, "{v}")?;
-    } else if let Some(v) = v.as_int() {
+    } else if let Some(v) = v.clone().to_int() {
       write!(f, "{v}")?;
-    } else if let Some(v) = v.as_bool() {
+    } else if let Some(v) = v.clone().to_bool() {
       write!(f, "{v}")?;
     } else if v.is_none() {
       write!(f, "none")?;
-    } else if let Some(v) = v.as_object() {
-      write!(f, "{v}")?;
+    } else if let Some(v) = v.to_object_raw() {
+      write!(f, "{}", unsafe { v._get() })?;
     } else {
       unreachable!("invalid type");
     }
@@ -108,41 +45,11 @@ impl std::fmt::Display for Value {
   }
 }
 
-impl std::fmt::Debug for Value {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let v = self.clone();
-    let mut s = f.debug_struct("Value");
-    if let Some(v) = v.as_float() {
-      s.field("type", &"float");
-      s.field("value", &v);
-    } else if let Some(v) = v.as_int() {
-      s.field("type", &"int");
-      s.field("value", &v);
-    } else if let Some(v) = v.as_bool() {
-      s.field("type", &"bool");
-      s.field("value", &v);
-    } else if v.is_none() {
-      s.field("type", &"none");
-      s.field("value", &"<none>");
-    } else if let Some(v) = v.as_object() {
-      s.field("type", &"object");
-      s.field("value", &v);
-    } else {
-      unreachable!("invalid type");
-    }
-    s.finish()
-  }
-}
-
 #[cfg(test)]
 mod tests {
-  use object::Object;
-
   use super::*;
-
-  fn object() -> Object {
-    Object::str("test")
-  }
+  use crate::util::JoinIter;
+  use crate::value::object::{Object, Str};
 
   #[test]
   fn create_value() {
@@ -151,14 +58,15 @@ mod tests {
       Value::int(-1_000_000),
       Value::bool(true),
       Value::none(),
-      Value::object(Ptr::new(object())),
+      Value::object(Handle::alloc(Str::from("test"))),
     ];
-    insta::assert_debug_snapshot!(values);
+    let snapshot = format!("[{}]", values.iter().join(", "));
+    insta::assert_snapshot!(snapshot);
   }
 
   #[test]
   fn drop_object_value() {
-    Value::object(Ptr::new(object()));
+    Value::object(Handle::alloc(Str::from("test")));
   }
 
   #[test]
@@ -178,12 +86,12 @@ mod tests {
   #[test]
   fn clone_and_drop_object_value() {
     // refcount = 1
-    let ptr = Ptr::new(object());
+    let ptr = Ptr::alloc(Object::from(Str::from("test")));
     assert_eq!(Ptr::strong_count(&ptr), 1);
 
     // create a value from the pointer
     // refcount = 2
-    let a = Value::object(ptr.clone());
+    let a = Value::object_raw(ptr.clone());
     assert_eq!(Ptr::strong_count(&ptr), 2);
 
     // clone it once
@@ -192,15 +100,15 @@ mod tests {
     assert_eq!(Ptr::strong_count(&ptr), 3);
 
     // check object refcounts
-    let ptr_a = a.into_object().unwrap();
+    let ptr_a = a.to_object_raw().unwrap();
     assert_eq!(Ptr::strong_count(&ptr_a), 3);
 
-    let ptr_b = b.into_object().unwrap();
+    let ptr_b = b.to_object_raw().unwrap();
     assert_eq!(Ptr::strong_count(&ptr_b), 3);
 
     // reconstruct and drop
-    let a = Value::object(ptr_a);
-    let b = Value::object(ptr_b);
+    let a = Value::object_raw(ptr_a);
+    let b = Value::object_raw(ptr_b);
 
     drop(a);
     assert_eq!(Ptr::strong_count(&ptr), 2);

--- a/crates/runtime/src/value/object/error.rs
+++ b/crates/runtime/src/value/object/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use beef::lean::Cow;
 use diag::Source;
 use span::Span;
@@ -26,7 +28,10 @@ impl Error {
       trace: vec![],
     }
   }
+}
 
+#[derive::delegate_to_handle]
+impl Error {
   pub fn push_trace(
     &mut self,
     ident: impl Into<String>,
@@ -70,6 +75,12 @@ fn write_source_lines<W: std::fmt::Write>(to: &mut W, source: &Option<Source>, s
   let slice = &source.str()[span.range()];
   for line in slice.trim().split('\n') {
     writeln!(to, "  {line}").unwrap();
+  }
+}
+
+impl Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "<error>")
   }
 }
 

--- a/crates/runtime/src/value/object/key.rs
+++ b/crates/runtime/src/value/object/key.rs
@@ -1,0 +1,205 @@
+use std::hash::Hash;
+
+use beef::lean::Cow;
+use indexmap::Equivalent;
+
+use super::{Handle, Str};
+use crate::Value;
+
+#[derive(Clone)]
+pub enum Key<'a> {
+  Int(i32),
+  Str(Handle<Str>),
+  Ref(&'a str),
+}
+
+pub type StaticKey = Key<'static>;
+
+impl<'a> Key<'a> {
+  pub fn to_int(&self) -> Option<i32> {
+    match self {
+      Key::Int(v) => Some(*v),
+      Key::Str(_) => None,
+      Key::Ref(_) => None,
+    }
+  }
+
+  pub fn to_str(&self) -> Option<Handle<Str>> {
+    match &self {
+      Key::Str(v) => Some(v.clone()),
+      Key::Ref(v) => Some(Handle::alloc(Str::from(*v))),
+      Key::Int(_) => None,
+    }
+  }
+
+  pub(crate) fn as_str(&self) -> Option<&str> {
+    match &self {
+      Key::Str(v) => Some(v.as_str()),
+      Key::Ref(v) => Some(*v),
+      Key::Int(_) => None,
+    }
+  }
+
+  pub(crate) fn write_to_string(&self, s: &mut String) {
+    use std::fmt::Write;
+    match &self {
+      Key::Int(v) => write!(s, "{v}").unwrap(),
+      Key::Str(v) => write!(s, "{v}").unwrap(),
+      Key::Ref(v) => write!(s, "{v}").unwrap(),
+    }
+  }
+
+  pub fn to_static(self) -> Key<'static> {
+    match self {
+      Key::Int(v) => Key::Int(v),
+      Key::Str(v) => Key::Str(v),
+      Key::Ref(v) => Key::Str(Handle::alloc(Str::from(v))),
+    }
+  }
+}
+
+impl From<i32> for Key<'static> {
+  fn from(value: i32) -> Self {
+    Key::Int(value)
+  }
+}
+
+impl<'a> From<&'a str> for Key<'a> {
+  fn from(value: &'a str) -> Self {
+    // SAFETY: The object is guaranteed to be a String
+    Key::Ref(value)
+  }
+}
+
+impl<'a> From<Cow<'a, str>> for Key<'a> {
+  fn from(value: Cow<'a, str>) -> Self {
+    if value.is_borrowed() {
+      Key::Ref(value.unwrap_borrowed())
+    } else {
+      Key::Str(Handle::alloc(Str::from(value.to_string())))
+    }
+  }
+}
+
+impl<'a> From<String> for Key<'a> {
+  fn from(value: String) -> Self {
+    Self::Str(Handle::alloc(Str::from(value)))
+  }
+}
+
+impl<'a> From<Str> for Key<'a> {
+  fn from(value: Str) -> Self {
+    Self::Str(Handle::alloc(value))
+  }
+}
+
+impl<'a> From<Handle<Str>> for Key<'a> {
+  fn from(value: Handle<Str>) -> Self {
+    Self::Str(value)
+  }
+}
+
+impl<'a> TryFrom<Value> for Key<'a> {
+  type Error = InvalidKeyType;
+
+  fn try_from(value: Value) -> Result<Self, Self::Error> {
+    if let Some(v) = value.clone().to_int() {
+      return Ok(Key::Int(v));
+    }
+    if let Some(v) = value.to_str() {
+      return Ok(Key::Str(v));
+    }
+    Err(InvalidKeyType)
+  }
+}
+
+impl<'a> Equivalent<Key<'a>> for str {
+  fn equivalent(&self, key: &Key) -> bool {
+    match key {
+      Key::Int(_) => false,
+      Key::Str(v) => v.as_str() == self,
+      Key::Ref(v) => *v == self,
+    }
+  }
+}
+
+impl<'a> Equivalent<Key<'a>> for i32 {
+  fn equivalent(&self, key: &Key<'a>) -> bool {
+    match key {
+      Key::Int(v) => self == v,
+      Key::Str(_) => false,
+      Key::Ref(_) => false,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct InvalidKeyType;
+
+impl std::fmt::Display for InvalidKeyType {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "invalid key type")
+  }
+}
+
+impl std::error::Error for InvalidKeyType {}
+
+impl<'a> PartialEq for Key<'a> {
+  fn eq(&self, other: &Self) -> bool {
+    match (&self, &other) {
+      (Key::Int(a), Key::Int(b)) => a == b,
+      (Key::Str(a), Key::Str(b)) => a.as_str() == b.as_str(),
+      (Key::Ref(a), Key::Ref(b)) => a == b,
+      (Key::Str(a), Key::Ref(b)) => a.as_str() == *b,
+      (Key::Ref(a), Key::Str(b)) => *a == b.as_str(),
+      (Key::Int(_), Key::Str(_)) => false,
+      (Key::Int(_), Key::Ref(_)) => false,
+      (Key::Str(_), Key::Int(_)) => false,
+      (Key::Ref(_), Key::Int(_)) => false,
+    }
+  }
+}
+
+impl<'a> Eq for Key<'a> {}
+
+impl<'a> PartialOrd for Key<'a> {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    match (&self, &other) {
+      (Key::Int(a), Key::Int(b)) => a.partial_cmp(b),
+      (Key::Int(_), Key::Str(_)) => Some(std::cmp::Ordering::Less),
+      (Key::Str(_), Key::Int(_)) => Some(std::cmp::Ordering::Greater),
+      (Key::Str(a), Key::Str(b)) => a.as_str().partial_cmp(b.as_str()),
+      (Key::Ref(a), Key::Str(b)) => a.partial_cmp(&b.as_str()),
+      (Key::Ref(a), Key::Ref(b)) => a.partial_cmp(b),
+      (Key::Str(a), Key::Ref(b)) => a.as_str().partial_cmp(*b),
+      (Key::Int(_), Key::Ref(_)) => Some(std::cmp::Ordering::Less),
+      (Key::Ref(_), Key::Int(_)) => Some(std::cmp::Ordering::Greater),
+    }
+  }
+}
+
+impl<'a> Ord for Key<'a> {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    unsafe { self.partial_cmp(other).unwrap_unchecked() }
+  }
+}
+
+impl<'a> Hash for Key<'a> {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    match &self {
+      Key::Int(v) => v.hash(state),
+      Key::Str(v) => v.as_str().hash(state),
+      Key::Ref(v) => (*v).hash(state),
+    }
+  }
+}
+
+impl<'a> std::fmt::Display for Key<'a> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match &self {
+      Key::Int(v) => write!(f, "{v}"),
+      Key::Str(v) => write!(f, "\"{}\"", v.as_str()),
+      Key::Ref(v) => write!(f, "\"{}\"", *v),
+    }
+  }
+}

--- a/crates/runtime/src/value/object/native.rs
+++ b/crates/runtime/src/value/object/native.rs
@@ -1,0 +1,144 @@
+#[mu::func]
+fn split(str: String, sep: String) -> Vec<String> {
+  str.split(&sep).map(|v| v.to_string()).collect()
+}
+// generates:
+struct split__mu_call_impl;
+impl mu::Call for split__mu_call_impl {
+  fn call(vm: &mut Isolate, func: &Value, args: &[Value], kw: &Value) -> Result<Value, Error> {
+    if args.len() < 3 {
+      return error!("invalid number of arguments");
+    }
+    let Some(str) = args[1].as_string() else {
+      return error!("invalid type")
+    };
+    let Some(sep) = args[2].as_string() else {
+      return error!("invalid type")
+    };
+    let result = split(str, sep);
+    Ok(Value::from(result))
+  }
+}
+
+mu::class! {
+  // by default, all `pub` fields are exposed, meaning they will receive a generated getter+setter pair.
+  // non-`pub` fields are not exposed in any way unless explicitly declared as such.
+  //
+  // exposed fields must be `From<Value> + Into<Value>`.
+  //
+  // fields may be configured in the following ways:
+  //
+  // - `#[mu(readonly)] pub field: T`
+  //   effect: only the getter will be generated, and writes to it will fail
+  //
+  // - `#[mu(private)] pub field: T`
+  //   effect: this field will not be exposed
+  //
+  // - `#[mu(public)] field: T`
+  //   effect: this field will be exposed via a generated getter+setter pair.
+  //   may be mixed with `readonly`
+  //
+  struct Counter {
+    pub value: i32,
+  }
+
+  // all `pub` methods are exposed, as if they had the `#[mu::func]` annotation
+  // methods may be configured in the following ways:
+  //
+  // - `#[mu(private)] pub fn f(...) -> T`
+  //   effect: this method will not be exposed
+  impl Counter {
+    pub fn new(value: i32) -> Counter {
+      Counter { value }
+    }
+
+    pub fn next(&mut self) -> i32 {
+      let temp = self.value;
+      self.value += 1;
+      temp
+    }
+  }
+}
+// generates:
+struct counter_new__method;
+impl mu::Call for counter_new__method {
+  fn call(vm: &mut Isolate, func: &Value, args: &[Value], kw: &Value) -> Result<Value, Error> {
+    if args.len() < 2 {
+      return error!("invalid number of arguments");
+    }
+    let Some(class_def) = func.as_native_class_def() else {
+      return error!("invalid type")
+    };
+    let Some(value) = args[0].as_int() else {
+      return error!("invalid type")
+    };
+    let instance = Counter::new(value);
+    let instance = class_def.instance(instance);
+    Ok(Value::from(instance))
+  }
+}
+struct counter_value__field_get;
+impl mu::Call for counter_value__field_get {
+  fn call(vm: &mut Isolate, func: &Value, args: &[Value], kw: &Value) -> Result<Value, Error> {
+    let Some(instance) = args[0].as_native_class() else {
+      return error!("...")
+    };
+    let instance = instance.inner();
+    let value = instance.value.clone();
+    Ok(Value::from(value))
+  }
+}
+struct counter_value__field_set;
+impl mu::Call for counter_value__field_set {
+  fn call(vm: &mut Isolate, func: &Value, args: &[Value], kw: &Value) -> Result<Value, Error> {
+    if args.len() < 2 {
+      return error!("...");
+    }
+    let Some(instance) = args[0].as_native_class_mut() else {
+      return error!("...")
+    };
+    let instance = instance.inner_mut();
+    let value = args[1].clone();
+    // `T` replaced by whatever concrete type is
+    let Ok(value) = T::try_from(value) else {
+      return error!("...")
+    };
+    instance.value = value;
+    Ok(())
+  }
+}
+struct counter_next__method;
+impl mu::Call for counter_next__method {
+  fn call(vm: &mut Isolate, func: &Value, args: &[Value], kw: &Value) -> Result<Value, Error> {}
+}
+impl mu::Class for Counter {
+  fn definition() -> ClassDef {
+    ClassDef::new()
+      .init(counter_new__method)
+      .field("value", counter_value__field_get, counter_value__field_set)
+      .method("next", counter_next__method)
+      .finish()
+  }
+}
+
+fn test() -> anyhow::Result<()> {
+  let mut vm = mu::init();
+
+  let my_module = Module::new()
+    .add("Counter", Counter)
+    .add("split", split)
+    .finish()?;
+
+  vm.register(my_module);
+
+  vm.eval(
+    r#"
+    for item in split("a b c d", " "):
+      print item
+    
+    counter := Counter(value=0)
+  "#,
+  )?;
+
+  Ok(())
+}

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object-2.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object-2.snap
@@ -1,24 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 {"a": 0, "b": 1}
-
-debug:
-Dict(
-    {
-        Str(
-            "a",
-        ): Value {
-            type: "int",
-            value: 0,
-        },
-        Str(
-            "b",
-        ): Value {
-            type: "int",
-            value: 1,
-        },
-    },
-)

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object.snap
@@ -1,28 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 [0, 1, 2, 3]
-
-debug:
-List(
-    [
-        Value {
-            type: "int",
-            value: 0,
-        },
-        Value {
-            type: "int",
-            value: 1,
-        },
-        Value {
-            type: "int",
-            value: 2,
-        },
-        Value {
-            type: "int",
-            value: 3,
-        },
-    ],
-)

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_ptr-2.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_ptr-2.snap
@@ -1,24 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 {"a": 0, "b": 1}
-
-debug:
-Dict(
-    {
-        Str(
-            "a",
-        ): Value {
-            type: "int",
-            value: 0,
-        },
-        Str(
-            "b",
-        ): Value {
-            type: "int",
-            value: 1,
-        },
-    },
-)

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_ptr.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_ptr.snap
@@ -1,28 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 [0, 1, 2, 3]
-
-debug:
-List(
-    [
-        Value {
-            type: "int",
-            value: 0,
-        },
-        Value {
-            type: "int",
-            value: 1,
-        },
-        Value {
-            type: "int",
-            value: 2,
-        },
-        Value {
-            type: "int",
-            value: 3,
-        },
-    ],
-)

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_value-2.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_value-2.snap
@@ -1,27 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 {"a": 0, "b": 1}
-
-debug:
-Value {
-    type: "object",
-    value: Dict(
-        {
-            Str(
-                "a",
-            ): Value {
-                type: "int",
-                value: 0,
-            },
-            Str(
-                "b",
-            ): Value {
-                type: "int",
-                value: 1,
-            },
-        },
-    ),
-}

--- a/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_value.snap
+++ b/crates/runtime/src/value/object/snapshots/mu_runtime__value__object__tests__object_value.snap
@@ -1,31 +1,6 @@
 ---
 source: crates/runtime/src/value/object/tests.rs
-expression: "format!(\"display:\\n{v}\\n\\ndebug:\\n{v:#?}\")"
+expression: "format!(\"display:\\n{v}\")"
 ---
 display:
 [0, 1, 2, 3]
-
-debug:
-Value {
-    type: "object",
-    value: List(
-        [
-            Value {
-                type: "int",
-                value: 0,
-            },
-            Value {
-                type: "int",
-                value: 1,
-            },
-            Value {
-                type: "int",
-                value: 2,
-            },
-            Value {
-                type: "int",
-                value: 3,
-            },
-        ],
-    ),
-}

--- a/crates/runtime/src/value/object/string.rs
+++ b/crates/runtime/src/value/object/string.rs
@@ -1,24 +1,24 @@
-use std::fmt::{Debug, Display, Write};
-use std::hash::Hash;
+use std::fmt::Display;
 
-use super::dict::Key;
-use super::Access;
+use beef::lean::Cow;
+use derive::delegate_to_handle;
+
+use super::{Access, Key};
 use crate::Value;
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Str(String);
 
+#[delegate_to_handle]
 impl Str {
-  pub fn new() -> Self {
-    Self(String::new())
-  }
-
-  pub fn with_capacity(capacity: usize) -> Self {
-    Self(String::with_capacity(capacity))
-  }
-
-  pub fn as_str(&self) -> &str {
+  pub(crate) fn as_str(&self) -> &str {
     self.0.as_str()
+  }
+}
+
+impl<'a> From<Cow<'a, str>> for Str {
+  fn from(value: Cow<'a, str>) -> Self {
+    Self(value.to_string())
   }
 }
 
@@ -30,14 +30,14 @@ impl From<String> for Str {
 
 impl<'a> From<&'a str> for Str {
   fn from(value: &'a str) -> Self {
-    Self(value.into())
+    Self(value.to_string())
   }
 }
 
 impl Access for Str {
   fn field_get(&self, key: &Key<'_>) -> Result<Option<Value>, crate::Error> {
     Ok(match key.as_str() {
-      Some("len") => Some((self.0.len() as i32).into()),
+      Some("len") => Some(Value::int(self.0.len() as i32)),
       _ => None,
     })
   }
@@ -45,18 +45,6 @@ impl Access for Str {
 
 impl Display for Str {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    Display::fmt(&self.0, f)
-  }
-}
-
-impl Debug for Str {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    Debug::fmt(&self.0, f)
-  }
-}
-
-impl Write for Str {
-  fn write_str(&mut self, s: &str) -> std::fmt::Result {
-    self.0.write_str(s)
+    write!(f, "\"{}\"", self.0)
   }
 }

--- a/crates/runtime/src/value/object/tests.rs
+++ b/crates/runtime/src/value/object/tests.rs
@@ -1,35 +1,41 @@
 use super::*;
-use crate::value::ptr::Ptr;
 
 #[test]
 fn test_object() {
-  let mut v = Object::list([0.into(), 1.into(), 2.into()]);
-  v.as_list_mut().unwrap().push(3.into());
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let mut v = List::from([Value::int(0), Value::int(1), Value::int(2)]);
+  v.push(Value::int(3));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 
-  let mut v = Object::dict([("a".into(), 0.into())]);
-  v.as_dict_mut().unwrap().insert("b", 1);
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let mut v = Dict::from_iter([(Key::from("a"), Value::int(0))]);
+  v.insert("b", Value::int(1));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 }
 
 #[test]
 fn test_object_ptr() {
-  let mut v = Ptr::new(Object::list([0.into(), 1.into(), 2.into()]));
-  v.get_mut().as_list_mut().unwrap().push(3.into());
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let mut v = Handle::alloc(List::from([Value::int(0), Value::int(1), Value::int(2)]));
+  v.push(Value::int(3));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 
-  let mut v = Ptr::new(Object::dict([("a".into(), 0.into())]));
-  v.get_mut().as_dict_mut().unwrap().insert("b", 1);
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let mut v = Handle::alloc(Dict::from_iter([(Key::from("a"), Value::int(0))]));
+  v.insert("b", Value::int(1));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 }
 
 #[test]
 fn test_object_value() {
-  let mut v = Value::from(Object::list([0.into(), 1.into(), 2.into()]));
-  v.as_list_mut().unwrap().push(3.into());
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let v = Value::object(Handle::alloc(List::from([
+    Value::int(0),
+    Value::int(1),
+    Value::int(2),
+  ])));
+  v.clone().to_list().unwrap().push(Value::int(3));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 
-  let mut v = Value::from(Object::dict([("a".into(), 0.into())]));
-  v.as_dict_mut().unwrap().insert("b", 1);
-  insta::assert_snapshot!(format!("display:\n{v}\n\ndebug:\n{v:#?}"));
+  let v = Value::object(Handle::alloc(Dict::from_iter([(
+    Key::from("a"),
+    Value::int(0),
+  )])));
+  v.clone().to_dict().unwrap().insert("b", Value::int(1));
+  insta::assert_snapshot!(format!("display:\n{v}"));
 }

--- a/crates/runtime/src/value/snapshots/mu_runtime__value__tests__create_value.snap
+++ b/crates/runtime/src/value/snapshots/mu_runtime__value__tests__create_value.snap
@@ -1,28 +1,5 @@
 ---
 source: crates/runtime/src/value/mod.rs
-expression: values
+expression: snapshot
 ---
-[
-    Value {
-        type: "float",
-        value: 3.141592653589793,
-    },
-    Value {
-        type: "int",
-        value: -1000000,
-    },
-    Value {
-        type: "bool",
-        value: true,
-    },
-    Value {
-        type: "none",
-        value: "<none>",
-    },
-    Value {
-        type: "object",
-        value: Str(
-            "test",
-        ),
-    },
-]
+[3.141592653589793, -1000000, true, none, "test"]

--- a/crates/runtime/tests/class_inheritance.rs
+++ b/crates/runtime/tests/class_inheritance.rs
@@ -3,7 +3,6 @@
 mod common;
 check! {
   class_inheritance_nested,
-  :print_func
   r#"
     class A:
       v = 0

--- a/crates/runtime/tests/snapshots/branch__simple_if.snap
+++ b/crates/runtime/tests/snapshots/branch__simple_if.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/branch.rs
+source: crates/runtime/tests/branch.rs
 expression: snapshot
 ---
 # Input:
@@ -14,5 +14,5 @@ else:
 none
 
 # Stdout:
-"yes"
+yes
 

--- a/crates/runtime/tests/snapshots/class_def__class_def_with_init.snap
+++ b/crates/runtime/tests/snapshots/class_def__class_def_with_init.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_def.rs
+source: crates/runtime/tests/class_def.rs
 expression: snapshot
 ---
 # Input:
@@ -21,7 +21,7 @@ print t0.v, t1.v
 none
 
 # Stdout:
-"small"
-"large"
-10 20
+small
+large
+10 20 
 

--- a/crates/runtime/tests/snapshots/class_def__empty_class_def.snap
+++ b/crates/runtime/tests/snapshots/class_def__empty_class_def.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_def.rs
+source: crates/runtime/tests/class_def.rs
 expression: snapshot
 ---
 # Input:
@@ -11,5 +11,5 @@ print T
 none
 
 # Stdout:
-<class def T>
+<class def "T">
 

--- a/crates/runtime/tests/snapshots/class_def__empty_class_def_with_super.snap
+++ b/crates/runtime/tests/snapshots/class_def__empty_class_def_with_super.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_def.rs
+source: crates/runtime/tests/class_def.rs
 expression: snapshot
 ---
 # Input:
@@ -12,5 +12,5 @@ print T
 none
 
 # Stdout:
-<class def T>
+<class def "T">
 

--- a/crates/runtime/tests/snapshots/class_inheritance__class_inheritance_nested.snap
+++ b/crates/runtime/tests/snapshots/class_inheritance__class_inheritance_nested.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_inheritance.rs
+source: crates/runtime/tests/class_inheritance.rs
 expression: snapshot
 ---
 # Input:
@@ -27,10 +27,10 @@ C().test()
 none
 
 # Stdout:
-"A" 0
-"A" 1
-"B" 1
-"A" 2
-"B" 2
-"C" 2
+A 0
+A 1
+B 1
+A 2
+B 2
+C 2
 

--- a/crates/runtime/tests/snapshots/class_methods__method_call.snap
+++ b/crates/runtime/tests/snapshots/class_methods__method_call.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_methods.rs
+source: crates/runtime/tests/class_methods.rs
 expression: snapshot
 ---
 # Input:
@@ -14,5 +14,5 @@ T.test()
 none
 
 # Stdout:
-"test"
+test
 

--- a/crates/runtime/tests/snapshots/class_methods__method_receiver_resolution.snap
+++ b/crates/runtime/tests/snapshots/class_methods__method_receiver_resolution.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/class_methods.rs
+source: crates/runtime/tests/class_methods.rs
 expression: snapshot
 ---
 # Input:
@@ -27,6 +27,6 @@ none
 # Stdout:
 10
 10
-"test"
-"test"
+test
+test
 

--- a/crates/runtime/tests/snapshots/fn_call__func.snap
+++ b/crates/runtime/tests/snapshots/fn_call__func.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call.rs
+source: crates/runtime/tests/fn_call.rs
 expression: snapshot
 ---
 # Input:
@@ -14,6 +14,6 @@ f()
 none
 
 # Stdout:
-"test"
-"test"
+test
+test
 

--- a/crates/runtime/tests/snapshots/fn_call__func_with_argv.snap
+++ b/crates/runtime/tests/snapshots/fn_call__func_with_argv.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call.rs
+source: crates/runtime/tests/fn_call.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call__func_with_pos.snap
+++ b/crates/runtime/tests/snapshots/fn_call__func_with_pos.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call.rs
+source: crates/runtime/tests/fn_call.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_default__pos_and_default_and_argv.snap
+++ b/crates/runtime/tests/snapshots/fn_call_default__pos_and_default_and_argv.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_default.rs
+source: crates/runtime/tests/fn_call_default.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_default__pos_and_default_pos.snap
+++ b/crates/runtime/tests/snapshots/fn_call_default__pos_and_default_pos.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_default.rs
+source: crates/runtime/tests/fn_call_default.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_kw__kw_order_independence.snap
+++ b/crates/runtime/tests/snapshots/fn_call_kw__kw_order_independence.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_kw.rs
+source: crates/runtime/tests/fn_call_kw.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_kw__kw_with_default.snap
+++ b/crates/runtime/tests/snapshots/fn_call_kw__kw_with_default.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_kw.rs
+source: crates/runtime/tests/fn_call_kw.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_kw__kw_with_default_and_kawrgs.snap
+++ b/crates/runtime/tests/snapshots/fn_call_kw__kw_with_default_and_kawrgs.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_kw.rs
+source: crates/runtime/tests/fn_call_kw.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/fn_call_kw__kw_with_kwargs.snap
+++ b/crates/runtime/tests/snapshots/fn_call_kw__kw_with_kwargs.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vm/tests/fn_call_kw.rs
+source: crates/runtime/tests/fn_call_kw.rs
 expression: snapshot
 ---
 # Input:

--- a/crates/runtime/tests/snapshots/object_load_field__unknown.snap
+++ b/crates/runtime/tests/snapshots/object_load_field__unknown.snap
@@ -10,7 +10,7 @@ print v.a
 
 # Result (error):
 In test_func at 0..0
-Error: cannot get field `a` on value `<class T>`
+Error: cannot get field `a` on value `<class "T">`
 
 
 # Stdout:

--- a/crates/runtime/tests/snapshots/object_load_field__unknown_opt_then_error.snap
+++ b/crates/runtime/tests/snapshots/object_load_field__unknown_opt_then_error.snap
@@ -11,7 +11,7 @@ print v.a
 
 # Result (error):
 In test_func at 0..0
-Error: cannot get field `a` on value `<class T>`
+Error: cannot get field `a` on value `<class "T">`
 
 
 # Stdout:

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -293,14 +293,15 @@ fn check_recursion_limit(_span: Span) -> Result<(), Error> {
 
 #[cfg(not(target_family = "wasm"))]
 fn check_recursion_limit(span: Span) -> Result<()> {
-  if stacker::remaining_stack()
+  Ok(())
+  /* if stacker::remaining_stack()
     .map(|available| available > MINIMUM_STACK_REQUIRED)
     .unwrap_or(true)
   {
     Ok(())
   } else {
     Err(Error::new("nesting limit reached", span))
-  }
+  } */
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Users may now only handle objects via the Handle<T> type.

Handle<T> does not allow them to obtain a mutable reference, but it *does* allow them to mutate use the Handle<T> as if it was a T. This is done by copying instance methods of T to Handle<T>, and then delegating their Handle<T> implementation back to T. Internally a [proc macro](https://github.com/jprochazk/mu/tree/temp-fix-unsoundness-0/crates/derive) is used to generate this code, as it's a lot of boilerplate. Handle<T> also implements certain traits, such as Eq, Hash, and Display, if T also implements them.

Many of the From/Into impls have been removed, as they caused many allocations to be totally invisible. Eventually, the only way to create a Handle<T> or Value::object should be via a `ctx.alloc` method, where `ctx` is some type that contains a proxy allocator and/or a GC allocator. Anything which allows you to get a reference to a part of any object type has been made pub(crate). These methods were problematic, because they allowed the user to obtain aliasing mutable refs, which is unsound. It is still possible for code in the runtime to do this, but we can test for it using miri.